### PR TITLE
Added note about repo not being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Recommended [vue-feather-icons](https://github.com/egoist/vue-feather-icons) for your project
+## This repo is no longer maintained
+
+Recommended [vue-feather-icons](https://github.com/egoist/vue-feather-icons) for your project instead.
 
 # vue-feather-icon
 


### PR DESCRIPTION
It wasn't obvious that the link to vue-feather-icons was an alternative project